### PR TITLE
Remove dependance on yoconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,19 @@ Get all our zones at CloudFlare
 
 ## Configuration
 
-The Host API service client is configured when it is instantiated and
-reads its configuration from `yoconfig`:
+The Host (Partner) API service client is configured when it is
+instantiated and reads its configuration from `configuration.json`.
 
-Django (or other) applications wishing to configure the service client,
-can use `yoconfig.configure_services`.
+The configuration file should be in the format:
 
-```python
-from yoconfig import configure_services
-
-configure_services('application_name', ['cloudflare'], {
-    'cloudflare': {
-        'api_key': '<api_key>',
-    },
-})
+```json
+{
+    "common": {
+        "cloudflare": {
+            "api_key": "HOST API KEY HERE",
+         }
+    }
+}
 ```
 
 ## Testing
@@ -40,3 +39,7 @@ Install development requirements:
 Tests can then be run by doing:
 
     nosetests
+
+The integration tests require a host API key. They can be run with:
+
+    nosetests tests/test_integration.py

--- a/pycloudflare/config.py
+++ b/pycloudflare/config.py
@@ -1,0 +1,18 @@
+import json
+
+
+def get_config():
+    """
+    Return credentials.
+
+    Either monkey patch this, or write a configuration file for it to read.
+    """
+    # Yola's internal configuration system:
+    try:
+        from yoconfig import get_config
+        return get_config('cloudflare')
+    except ImportError:
+        pass
+
+    with open('configuration.json') as f:
+        return json.load(f)['common']['cloudflare']

--- a/pycloudflare/services.py
+++ b/pycloudflare/services.py
@@ -1,8 +1,8 @@
 from urllib import urlencode
 
 from demands import HTTPServiceClient, HTTPServiceError
-from yoconfig import get_config
 
+from pycloudflare.config import get_config
 from pycloudflare.pagination import PaginatedAPIIterator
 
 
@@ -100,7 +100,7 @@ class CloudFlareHostPageIterator(PaginatedAPIIterator):
 
 class CloudFlareHostService(HTTPServiceClient):
     def __init__(self, **kwargs):
-        config = get_config('cloudflare')
+        config = get_config()
         data = {
             'host_key': config['api_key'],
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ demands == 1.0.6
 mock == 1.0.1
 nose == 1.3.4
 property-caching == 1.0.3
-yoconfig == 0.2.0
 yoconfigurator == 0.4.6

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,5 @@ setup(
     install_requires=[
         'demands >= 1.0.5, < 2.0.0',
         'property-caching >= 1.0.0, < 2.0.0',
-        'yoconfig >= 0.1.0, < 0.2.0',
     ]
 )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,10 +1,7 @@
-import os
 from unittest import TestCase
 from uuid import uuid4
 
 from demands import HTTPServiceError
-from yoconfigurator.base import read_config
-from yoconfig import configure_services
 
 from pycloudflare.services import (
     CloudFlareHostPageIterator, CloudFlareHostService, CloudFlarePageIterator,
@@ -15,10 +12,6 @@ TEST_USER = {}
 
 
 def setUpModule():
-    app_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-    conf = read_config(app_dir)
-    configure_services('cloudflare', ['cloudflare'], conf.common)
-
     cfh = CloudFlareHostService()
     TEST_USER['password'] = uuid4().hex
     TEST_USER['unique_id'] = uuid4().hex


### PR DESCRIPTION
But use it if it's available. yoconfig isn't public because it does things that are a bit specific to Yola :(
