### PR TITLE
Move attributes required for SRV record creation into the necessary data field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+* Move attributes required for SRV records into the correct field.
+
 ## 0.2.0
 
 * Add SRV record support to allow for the creation of SRV DNS records.

--- a/pycloudflare/__init__.py
+++ b/pycloudflare/__init__.py
@@ -1,4 +1,4 @@
 """Python client for CloudFlare."""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __url__ = 'https://github.com/yola/pycloudflare'

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -208,7 +208,7 @@ class Record(object):
         raise AttributeError()
 
     def __setattr__(self, name, value):
-        if name in self._record_attrs:
+        if name in self._own_attrs:
             return super(Record, self).__setattr__(name, value)
         if name in self._data:
             if name == 'name':

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -194,13 +194,13 @@ class ZoneSettings(object):
 
 class Record(object):
     _data = ()
-    _own_attrs = ('zone', '_service', '_data', '_old_data')
+    _own_attrs = ('zone', '_service', '_data', '_saved_data')
 
     def __init__(self, zone, data):
         self.zone = zone
         self._service = zone._service
         self._data = data
-        self._old_data = deepcopy(data)
+        self._saved_data = deepcopy(data)
 
     def __getattr__(self, name):
         if name in self._data:
@@ -216,12 +216,12 @@ class Record(object):
             raise AttributeError()
 
     def save(self):
-        if self._old_data != self._data:
+        if self._saved_data != self._data:
             result = self._service.update_dns_record(self.zone.id, self.id,
                                                      self._data)
-            if self._data['name'] != self._old_data['name']:
+            if self._data['name'] != self._saved_data['name']:
                 clear_property_cache(self.zone, 'records')
-            self._old_data = result
+            self._saved_data = result
 
     def delete(self):
         self._service.delete_dns_record(self.zone.id, self.id)

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -205,8 +205,6 @@ class Record(object):
     def __getattr__(self, name):
         if name in self._data:
             return self._data[name]
-        if name in self._old_data:
-            return self._old_data[name]
         raise AttributeError()
 
     def __setattr__(self, name, value):

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -192,8 +192,8 @@ class ZoneSettings(object):
 
 class Record(object):
     _data = ()
-    _record_attrs = ('zone', '_service', '_data',
-                     '_was_updated', '_clear_cache')
+    _own_attrs = ('zone', '_service', '_data',
+                  '_was_updated', '_clear_cache')
 
     def __init__(self, zone, data):
         self.zone = zone
@@ -211,7 +211,8 @@ class Record(object):
         if name in self._record_attrs:
             return super(Record, self).__setattr__(name, value)
         if name in self._data:
-            self._clear_cache = (name == 'name')
+            if name == 'name':
+                self._clear_cache = True
             self._data[name] = value
             self._was_updated = True
         else:

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -127,14 +127,15 @@ class Zone(object):
         if record_type == 'MX':
             data['priority'] = kwargs['priority']
         elif record_type == 'SRV':
-            data.update(
-                service=kwargs['service'],
-                proto=kwargs['protocol'],
-                priority=kwargs['priority'],
-                weight=kwargs['weight'],
-                port=kwargs['port'],
-                target=kwargs['target'],
-            )
+            data['data'] = {
+                'name': name,
+                'service': kwargs['service'],
+                'proto': kwargs['protocol'],
+                'priority': kwargs['priority'],
+                'weight': kwargs['weight'],
+                'port': kwargs['port'],
+                'target': kwargs['target'],
+            }
 
         record = self._service.create_dns_record(self.id, data)
         clear_property_cache(self, 'records')

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -160,8 +160,9 @@ class FakeService(object):
             'zone_name': self.zones[zone_id]['name'],
             'created_on': '2014-01-01T05:20:00.12345Z',
             'modified_on': '2014-01-01T05:20:00.12345Z',
-            'data': {},
         })
+        if 'data' not in data:
+            data['data'] = {}
         self.zones[zone_id]['_records'].append(data)
         return deepcopy(data)
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -161,8 +161,7 @@ class FakeService(object):
             'created_on': '2014-01-01T05:20:00.12345Z',
             'modified_on': '2014-01-01T05:20:00.12345Z',
         })
-        if 'data' not in data:
-            data['data'] = {}
+        data.setdefault('data', {})
         self.zones[zone_id]['_records'].append(data)
         return deepcopy(data)
 

--- a/tests/models/test_record.py
+++ b/tests/models/test_record.py
@@ -133,7 +133,7 @@ class TestUpdateRecord(FakedServiceTestCase):
         with patch.object(self.record._service, 'update_dns_record'):
             self.record.save()
             self.record._service.update_dns_record.assert_called_with(
-                self.zone.id, self.record.id, {'proxied': True})
+                self.zone.id, self.record.id, self.record._data)
 
     def test_invalidates_zone_records_on_rename(self):
         self.assertNotIn('quux.example.com', self.zone.records)

--- a/tests/models/test_record.py
+++ b/tests/models/test_record.py
@@ -79,22 +79,22 @@ class TestCreateSRVRecord(FakedServiceTestCase):
         )
 
     def test_sets_priority(self):
-        self.assertEqual(self.test_record.priority, 10)
+        self.assertEqual(self.test_record.data['priority'], 10)
 
     def test_sets_weight(self):
-        self.assertEqual(self.test_record.weight, 5)
+        self.assertEqual(self.test_record.data['weight'], 5)
 
     def test_sets_service(self):
-        self.assertEqual(self.test_record.service, '_sip')
+        self.assertEqual(self.test_record.data['service'], '_sip')
 
     def test_sets_protocol(self):
-        self.assertEqual(self.test_record.proto, '_tcp')
+        self.assertEqual(self.test_record.data['proto'], '_tcp')
 
     def test_sets_port(self):
-        self.assertEqual(self.test_record.port, 8806)
+        self.assertEqual(self.test_record.data['port'], 8806)
 
     def test_sets_target(self):
-        self.assertEqual(self.test_record.target, 'example.net')
+        self.assertEqual(self.test_record.data['target'], 'example.net')
 
 
 class TestDeleteRecord(FakedServiceTestCase):


### PR DESCRIPTION
The values the SRV record uses are required to be held in `data` as defined [here](https://api.cloudflare.com/#dns-records-for-a-zone-properties): 

> SRV Record
> ```
{
  "type": "SRV",
  ...,
  "data": {
    "service": "_sip",
    "proto": "_tcp",
    "name": "example.com",
    "priority": 10,
    "weight": 5,
    "port": 8806,
    "target": "somewhere.com"
  }
}
```