### PR TITLE
Ensure data is the same after `save`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.2
+
+* Assign `_data` to the returned result as the `Record` meta values change on
+`save`.
+
 ## 0.2.1
 
 * Move attributes required for SRV records into the correct field.

--- a/pycloudflare/__init__.py
+++ b/pycloudflare/__init__.py
@@ -1,4 +1,4 @@
 """Python client for CloudFlare."""
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 __url__ = 'https://github.com/yola/pycloudflare'

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -199,8 +199,7 @@ class Record(object):
     def __init__(self, zone, data):
         self.zone = zone
         self._service = zone._service
-        self._data = data
-        self._saved_data = deepcopy(data)
+        self._set_data(data)
 
     def __getattr__(self, name):
         if name in self._data:
@@ -215,13 +214,17 @@ class Record(object):
         else:
             raise AttributeError()
 
+    def _set_data(self, data):
+        self._saved_data = data
+        self._data = deepcopy(data)
+
     def save(self):
         if self._saved_data != self._data:
             result = self._service.update_dns_record(self.zone.id, self.id,
                                                      self._data)
             if self._data['name'] != self._saved_data['name']:
                 clear_property_cache(self.zone, 'records')
-            self._saved_data = result
+            self._set_data(result)
 
     def delete(self):
         self._service.delete_dns_record(self.zone.id, self.id)

--- a/tests/models/test_record.py
+++ b/tests/models/test_record.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from mock import patch
 from six import string_types
 
@@ -130,10 +132,12 @@ class TestUpdateRecord(FakedServiceTestCase):
 
     def test_save_performs_update(self):
         self.record.proxied = True
+        record_id = self.record.id
+        record_data = deepcopy(self.record._data)
         with patch.object(self.record._service, 'update_dns_record'):
             self.record.save()
             self.record._service.update_dns_record.assert_called_with(
-                self.zone.id, self.record.id, self.record._data)
+                self.zone.id, record_id, record_data)
 
     def test_invalidates_zone_records_on_rename(self):
         self.assertNotIn('quux.example.com', self.zone.records)


### PR DESCRIPTION
The `Record` returned after calling save would have had it's `meta` field update to include that latest modified date which means after calling `save` the two data containers would already be different.

This fixes that by updating both data containers at the end of `save`.