### PR TITLE
Include README.rst in MANIFEST.ini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.3
+
+* Include `README.rst` file in package, since `setup.py` depends on it
+
 ## 0.2.2
 
 * Assign `_data` to the returned result as the `Record` meta values change on

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include LICENSE
 include CHANGELOG.md
-include README.md
+include README.rst
 recursive-include tests *.py

--- a/pycloudflare/__init__.py
+++ b/pycloudflare/__init__.py
@@ -1,4 +1,4 @@
 """Python client for CloudFlare."""
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 __url__ = 'https://github.com/yola/pycloudflare'


### PR DESCRIPTION
I think that will fix:
```
Running pycloudflare-0.2.2/setup.py -q bdist_egg --dist-dir /tmp/easy_install-AHldWZ/pycloudflare-0.2.2/egg-dist-tmp-RuuUFY
error: [Errno 2] No such file or directory: 'README.rst'
Traceback (most recent call last):
  File "/home/acefire6/yola/yodeploy/yodeploy/cmds/build_virtualenv.py", line 118, in <module>
    main()
  File "/home/acefire6/yola/yodeploy/yodeploy/cmds/build_virtualenv.py", line 109, in main
    req_file=options.requirement)
  File "/home/acefire6/yola/yodeploy/yodeploy/cmds/../../yodeploy/virtualenv.py", line 99, in create_ve
    subprocess.check_call(cmd, cwd=ve_dir)
  File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
```