### PR TITLE
Add `models.Zone.purge_cache` method (and corresponding service support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## DEV
+
+* Add `models.Zone.purge_cache` method (and corresponding service support).
+
 ## 0.3.2
 
 * Add `models.User.create_cname_zone` method.

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -149,6 +149,9 @@ class Zone(object):
         clear_property_cache(self, 'records')
         return Record(self, record)
 
+    def purge_cache(self, files=None, tags=None):
+        self._service.purge_cache(self.id, files=files, tags=tags)
+
     def __repr__(self):
         return 'Zone<%s>' % self.name
 

--- a/pycloudflare/services.py
+++ b/pycloudflare/services.py
@@ -95,6 +95,16 @@ class CloudFlareService(HTTPServiceClient):
     def delete_dns_record(self, zone_id, record_id):
         return self.delete('zones/%s/dns_records/%s' % (zone_id, record_id))
 
+    def purge_cache(self, zone_id, files=None, tags=None):
+        data = {}
+        if files:
+            data['files'] = files
+        if tags:
+            data['tags'] = tags
+        if files is None and tags is None:
+            data['purge_everything'] = True
+        return self.delete('zones/%s/purge_cache' % zone_id, json=data)
+
 
 class CloudFlareHostPageIterator(PaginatedAPIIterator):
     page_param = 'offset'

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -196,3 +196,6 @@ class FakeService(object):
             raise Exception('Not Found')
         record.update(data)
         return deepcopy(record)
+
+    def purge_cache(self, zone_id, files=None, tags=None):
+        return

--- a/tests/models/test_zone.py
+++ b/tests/models/test_zone.py
@@ -93,3 +93,12 @@ class TestSetCNameZone(FakedServiceTestCase):
             'resolving_to': 'resolve-to.example.org'
         }
         self.assertEqual(self.result, expected_response)
+
+
+class TestPurgeZone(FakedServiceTestCase):
+    def setUp(self):
+        self.user = User.get(email='foo@example.net')
+        self.zone = self.user.get_zone_by_name('example.com')
+
+    def test_full_purge(self):
+        self.zone.purge_cache()


### PR DESCRIPTION
I'm unable to add an integration test, because CloudFlare seems to reject purge requests for our test domain (presumably because it isn't verified and live).

The error is:
```
HTTPServiceError: Unexpected response: url: https://api.cloudflare.com/client/v4/zones/71a5828f120c11b844eeadd6a28b6c24/purge_cache, code: 400, details: {u'errors': [{u'message': u'Sorry, you do not have access to purge cache for that zone id or that zone id is invalid', u'code': 1095}], u'messages': [], u'result': None, u'success': False}
```