### PR TITLE
Allow toggling Universal SSL on a CNAME zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.4
+
+* Allow toggling Universal SSL on a CNAME zone, to re-verify it.
+
 ## 0.4.3
 
 * Fix bug in HTTP errors translation.

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -197,6 +197,11 @@ class Zone(object):
     def get_ssl_verification_info(self):
         return self._service.get_ssl_verification_info(self.id)
 
+    def re_verify(self):
+        for state in (False, True):
+            self._service.update_ssl_universal_settings(
+                self.id, {'enabled': state})
+
     def __repr__(self):
         return 'Zone<%s>' % self.name
 

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -198,6 +198,10 @@ class Zone(object):
         return self._service.get_ssl_verification_info(self.id)
 
     def re_verify(self):
+        """Toggle Universal SSL off and on, to trigger re-verification.
+
+        This will leave SSL enabled, regardless of the previous state.
+        """
         for state in (False, True):
             self._service.update_ssl_universal_settings(
                 self.id, {'enabled': state})

--- a/pycloudflare/services.py
+++ b/pycloudflare/services.py
@@ -132,6 +132,13 @@ class CloudFlareService(HTTPServiceClient):
             data['purge_everything'] = True
         return self.delete('zones/%s/purge_cache' % zone_id, json=data)
 
+    def get_ssl_universal_settings(self, zone_id):
+        return self.get('zones/%s/ssl/universal/settings' % zone_id)
+
+    def update_ssl_universal_settings(self, zone_id, content):
+        return self.patch(
+            'zones/%s/ssl/universal/settings' % zone_id, json=content)
+
     def get_ssl_verification_info(self, zone_id):
         return self.get('zones/%s/ssl/verification' % zone_id)
 


### PR DESCRIPTION
This re-starts the verification process, if it had timed out.