### PR TITLE
Add optional `hosts` parameter to `CloudFlareService.purge_cache()` method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
 - 2.7
 - 3.5
 - 3.6
+- 3.7
+- 3.8
 - pypy
 install:
 - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
 - 2.7
-- 3.5
 - 3.6
 - 3.7
 - 3.8
+- 3.9
 - pypy
 install:
 - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
 - 2.7
-- 3.3
-- 3.4
+- 3.5
+- 3.6
 - pypy
 install:
 - pip install -r requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.6
+
+* Add optional `hosts` parameter to `CloudFlareService.purge_cache()` method.
+* Add optional `hosts` parameter to `models.Zone.purge_cache()` method.
+
 ## 0.4.5
 
 * Insert a delay in the Universal SSL toggling, so it takes effect.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.6
+## 1.0.0
 
 * Add optional `hosts` parameter to `CloudFlareService.purge_cache()` method.
 * Add optional `hosts` parameter to `models.Zone.purge_cache()` method.

--- a/pycloudflare/__init__.py
+++ b/pycloudflare/__init__.py
@@ -1,4 +1,4 @@
 """Python client for CloudFlare."""
 
-__version__ = '0.4.5'
+__version__ = '0.4.6'
 __url__ = 'https://github.com/yola/pycloudflare'

--- a/pycloudflare/__init__.py
+++ b/pycloudflare/__init__.py
@@ -1,4 +1,4 @@
 """Python client for CloudFlare."""
 
-__version__ = '0.4.6'
+__version__ = '1.0.0'
 __url__ = 'https://github.com/yola/pycloudflare'

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -191,8 +191,9 @@ class Zone(object):
         clear_property_cache(self, 'page_rules')
         return PageRule(self, page_rule)
 
-    def purge_cache(self, files=None, tags=None):
-        self._service.purge_cache(self.id, files=files, tags=tags)
+    def purge_cache(self, files=None, tags=None, hosts=None):
+        self._service.purge_cache(
+            self.id, files=files, tags=tags, hosts=hosts)
 
     @translate_errors(1001, SSLUnavailable)
     def get_ssl_verification_info(self):

--- a/pycloudflare/services.py
+++ b/pycloudflare/services.py
@@ -122,7 +122,7 @@ class CloudFlareService(HTTPServiceClient):
     def delete_page_rule(self, zone_id, rule_id):
         return self.delete('zones/%s/pagerules/%s' % (zone_id, rule_id))
 
-    def purge_cache(self, zone_id, files=None, tags=None):
+    def purge_cache(self, zone_id, files=None, tags=None, hosts=None):
         data = {}
         if files:
             data['files'] = files
@@ -130,6 +130,9 @@ class CloudFlareService(HTTPServiceClient):
             data['tags'] = tags
         if files is None and tags is None:
             data['purge_everything'] = True
+        if hosts:
+            data['hosts'] = hosts
+
         return self.delete('zones/%s/purge_cache' % zone_id, json=data)
 
     def get_ssl_universal_settings(self, zone_id):

--- a/pycloudflare/services.py
+++ b/pycloudflare/services.py
@@ -128,10 +128,11 @@ class CloudFlareService(HTTPServiceClient):
             data['files'] = files
         if tags:
             data['tags'] = tags
-        if files is None and tags is None:
-            data['purge_everything'] = True
         if hosts:
             data['hosts'] = hosts
+
+        if not data:
+            data['purge_everything'] = True
 
         return self.delete('zones/%s/purge_cache' % zone_id, json=data)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,12 @@
+from mock import patch
+
+
+class PatchMixin(object):
+    def _patch(self, target, *args, **kwargs):
+        if isinstance(target, str):
+            patcher = patch(target, *args, **kwargs)
+        else:
+            patcher = patch.object(target, *args, **kwargs)
+        patched_entity = patcher.start()
+        self.addCleanup(patcher.stop)
+        return patched_entity

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -252,5 +252,5 @@ class FakeService(object):
     def update_page_rule(self, zone_id, page_rule_id, data):
         return self._update_object('_page_rules', zone_id, page_rule_id, data)
 
-    def purge_cache(self, zone_id, files=None, tags=None):
+    def purge_cache(self, zone_id, files=None, tags=None, hosts=None):
         return

--- a/tests/models/test_zone.py
+++ b/tests/models/test_zone.py
@@ -151,7 +151,7 @@ class TestGetSSLVerificationInfoForZoneWithError(FakedServiceTestCase):
 class TestPurgeZone(TestCase, PatchMixin):
 
     def setUp(self):
-        self.service_mock = serlf._patch(
+        self.service_mock = self._patch(
             'pycloudflare.models.CloudFlareService')
         self.zone = Zone(User('email', 'api_key'), {'id': 'zone_id'})
 

--- a/tests/models/test_zone.py
+++ b/tests/models/test_zone.py
@@ -1,10 +1,11 @@
-from mock import Mock, patch
+from mock import Mock
 from six import string_types
 from unittest import TestCase
 
 from pycloudflare.exceptions import SSLUnavailable
 from pycloudflare.models import PageRule, Record, User, Zone
 from pycloudflare.services import HTTPServiceError
+from tests import PatchMixin
 from tests.models import FakedServiceTestCase
 
 
@@ -147,15 +148,12 @@ class TestGetSSLVerificationInfoForZoneWithError(FakedServiceTestCase):
         self.assertRaises(SSLUnavailable, self.zone.get_ssl_verification_info)
 
 
-class TestPurgeZone(TestCase):
+class TestPurgeZone(TestCase, PatchMixin):
 
     def setUp(self):
-        self.service_mock = patch(
-            'pycloudflare.models.CloudFlareService').start()
+        self.service_mock = serlf._patch(
+            'pycloudflare.models.CloudFlareService')
         self.zone = Zone(User('email', 'api_key'), {'id': 'zone_id'})
-
-    def tearDown(self):
-        self.service_mock.stop()
 
     def test_full_purge(self):
         self.zone.purge_cache()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from mock import patch
 from unittest import TestCase
 
 from pycloudflare.services import CloudFlareService

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -10,9 +10,6 @@ class TestPurgeZoneCache(TestCase, PatchMixin):
         self.delete_mock = self._patch(
             'pycloudflare.services.CloudFlareService.delete')
 
-    def tearDown(self):
-        self.delete_mock.stop()
-
     def test_full_purge(self):
         CloudFlareService('api_key', 'email').purge_cache('zone_id')
         self.delete_mock.assert_called_once_with(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,27 @@
+from mock import Mock, patch
+from unittest import TestCase
+
+from pycloudflare.services import CloudFlareService
+
+
+class TestPurgeZoneCache(TestCase):
+
+    def setUp(self):
+        self.delete_mock = patch(
+            'pycloudflare.services.CloudFlareService.delete').start()
+
+    def tearDown(self):
+        self.delete_mock.stop()
+
+    def test_full_purge(self):
+        CloudFlareService('api_key', 'email').purge_cache('zone_id')
+        self.delete_mock.assert_called_once_with(
+            'zones/zone_id/purge_cache', json={'purge_everything': True})
+
+    def test_partial_purge(self):
+        CloudFlareService('api_key', 'email').purge_cache(
+            'zone_id', hosts=['h1', 'h2'], tags=['t1', 't2'])
+        self.delete_mock.assert_called_once_with(
+            'zones/zone_id/purge_cache',
+            json={'hosts': ['h1', 'h2'], 'tags': ['t1', 't2']}
+        )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,14 +1,14 @@
-from mock import patch
 from unittest import TestCase
 
 from pycloudflare.services import CloudFlareService
+from tests import PatchMixin
 
 
-class TestPurgeZoneCache(TestCase):
+class TestPurgeZoneCache(TestCase, PatchMixin):
 
     def setUp(self):
-        self.delete_mock = patch(
-            'pycloudflare.services.CloudFlareService.delete').start()
+        self.delete_mock = self._patch(
+            'pycloudflare.services.CloudFlareService.delete')
 
     def tearDown(self):
         self.delete_mock.stop()


### PR DESCRIPTION
closes: #46 

* Add optional `hosts` parameter to `CloudFlareService.purge_cache()` method
* Add optional `hosts` parameter to `models.Zone.purge_cache()` method.