### PR TITLE
Remove pagination from CloudFlareService.get_zone_settings() - settings API isn't paginated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0
+* Remove pagination from `CloudFlareService.get_zone_settings()` since
+  the corresponding API isn't paginated.
+
 ## 1.0.0
 
 * Add optional `hosts` parameter to `CloudFlareService.purge_cache()` method.

--- a/pycloudflare/__init__.py
+++ b/pycloudflare/__init__.py
@@ -1,4 +1,4 @@
 """Python client for CloudFlare."""
 
-__version__ = '1.0.0'
+__version__ = '2.0.0'
 __url__ = 'https://github.com/yola/pycloudflare'

--- a/pycloudflare/models.py
+++ b/pycloudflare/models.py
@@ -232,8 +232,7 @@ class ZoneSettings(object):
 
     def _get_settings(self):
         self._settings = {}
-        for setting in cloudflare_paginated_results(
-                self._service.get_zone_settings, args=(self.zone.id,)):
+        for setting in self._service.get_zone_settings(self.zone.id):
             self._settings[setting['id']] = setting
 
     def __getattr__(self, name):

--- a/pycloudflare/services.py
+++ b/pycloudflare/services.py
@@ -58,10 +58,8 @@ class CloudFlareService(HTTPServiceClient):
 
         return result[0]
 
-    def get_zone_settings(self, zone_id, page=1,
-                          per_page=CF_PAGINATION_OPTIONS[PAGE_SIZE]):
-        url = 'zones/%s/settings' % zone_id
-        return self._get_paginated(url, page, per_page)
+    def get_zone_settings(self, zone_id):
+        return self.get('zones/%s/settings' % zone_id)
 
     def set_zone_settings(self, zone_id, items):
         data = {'items': items}

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -181,10 +181,8 @@ class FakeService(object):
     def delete_zone(self, zone_id):
         del self.zones[zone_id]
 
-    def get_zone_settings(self, zone_id, page=1, per_page=50):
-        page -= 1  # Map to our 0-indexed list
-        settings = list(self.zones[zone_id]['_settings'].values())
-        return deepcopy(settings[page:page + per_page])
+    def get_zone_settings(self, zone_id):
+        return deepcopy(list(self.zones[zone_id]['_settings'].values()))
 
     def set_zone_settings(self, zone_id, items):
         for setting in items:


### PR DESCRIPTION
A part of https://github.com/yola/p-whitelabel/issues/1652

Docs: https://api.cloudflare.com/#zone-settings-get-all-zone-settings